### PR TITLE
Fix unexpected_cfgs lint errors in QA build

### DIFF
--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--check-cfg=cfg(feature,values(\"cargo-clippy\"))"]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -59,6 +59,9 @@ monitor = { git = "https://github.com/ahkohd/tauri-toolkit", branch = "v2" }
 name = "generate_schema"
 path = "src/bin/generate_schema.rs"
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(feature, values(\"cargo-clippy\"))"] }
+
 [dependencies.rusqlite]
 version = "0.32"
 features = ["bundled"]


### PR DESCRIPTION
Fixes lint errors that occur when the objc crate macros use cfg(feature = "cargo-clippy") internally, triggering unexpected_cfgs warnings that become errors with -D warnings enabled. Add [lints.rust] section to Cargo.toml and .cargo/config.toml to declare this as expected.

## Test plan
- Verify QA build succeeds without unexpected_cfgs lint errors
- Ensure existing tests and build pass