### PR TITLE
Update educational tooltip for open source launch

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -77,7 +77,6 @@ import * as AppMetadataAPI from "@core/chorus/api/AppMetadataAPI";
 import * as ToolsetsAPI from "@core/chorus/api/ToolsetsAPI";
 import * as ChatAPI from "@core/chorus/api/ChatAPI";
 import * as ProjectAPI from "@core/chorus/api/ProjectAPI";
-import { RiOpenaiFill } from "react-icons/ri";
 
 scan({
     enabled: true,
@@ -797,12 +796,11 @@ function AppContent() {
                         </button>
 
                         <AlertTitle className="flex items-center gap-2">
-                            <RiOpenaiFill className="w-4 h-4" />
-                            GPT-5
+                            Open Source
                         </AlertTitle>
                         <AlertDescription>
-                            The GPT-5 family of models are now available in
-                            Chorus!
+                            Chorus is now Open Source! It now runs on your own
+                            API keys. Add them in Settings → API Keys.
                             <br />
                             <br />
                             <div className="gap-4 mt-2">
@@ -810,11 +808,11 @@ function AppContent() {
                                     className="text-sm text-muted-foreground hover:text-foreground"
                                     onClick={() =>
                                         void openUrl(
-                                            "https://chorus.sh/changelog",
+                                            "https://github.com/meltylabs/chorus",
                                         )
                                     }
                                 >
-                                    See all changes
+                                    Learn more
                                 </button>
                             </div>
                         </AlertDescription>

--- a/src/ui/components/ApiKeysForm.tsx
+++ b/src/ui/components/ApiKeysForm.tsx
@@ -79,7 +79,7 @@ export default function ApiKeysForm({
                     >
                         <div className="flex flex-col items-center gap-2 text-center">
                             {provider.id === "firecrawl" ? (
-                                <FlameIcon className="w-8 h-8 text-orange-500" />
+                                <FlameIcon className="w-4 h-4" />
                             ) : (
                                 <ProviderLogo
                                     provider={provider.id as ProviderName}


### PR DESCRIPTION
Update the educational tooltip to announce Chorus is now open source and runs on user's own API keys.

**Changes:**
- Updated tooltip title from "GPT-5" to "Open Source"
- Added message about running on user's own API keys with setup instructions
- Changed link to GitHub repository
- Fixed Firecrawl icon size and removed orange color to match other provider icons

**Test plan:**
- [ ] Verify the educational tooltip displays on app launch
- [ ] Verify the tooltip text displays correctly: "Chorus is now Open Source! It now runs on your own API keys. Add them in Settings → API Keys."
- [ ] Verify the "Learn more" button links to https://github.com/meltylabs/chorus
- [ ] Verify the Firecrawl icon in Settings → API Keys matches the size of other provider icons
- [ ] Verify the Firecrawl icon is no longer orange

🤖 Generated with [Claude Code](https://claude.com/claude-code)