### PR TITLE
Rename interactive_release npm script to release

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "validate": "./script/validate.sh",
         "validate:fix": "./script/validate.sh --fix",
         "delete-db": "./script/delete-db.sh",
-        "interactive_release": "./script/interactive_release.sh",
+        "release": "./script/interactive_release.sh",
         "prepare": "husky"
     },
     "engines": {


### PR DESCRIPTION
## Summary
Rename the `interactive_release` npm script to `release` for brevity and better consistency with common convention.

## Test plan
- Verify that `pnpm release` works as expected (should execute `./script/interactive_release.sh`)
- Verify that the release workflow functions properly with the renamed script