### PR TITLE
Bump node version 20 -> 22

### DIFF
--- a/.github/workflows/cloud-publish-migration.yaml
+++ b/.github/workflows/cloud-publish-migration.yaml
@@ -44,7 +44,7 @@ jobs:
                   version: 9
             - uses: actions/setup-node@v4
               with:
-                  node-version: "20"
+                  node-version: "22"
             - name: Install stable toolchain
               uses: actions-rust-lang/setup-rust-toolchain@v1
               with:

--- a/.github/workflows/cloud-publish.yaml
+++ b/.github/workflows/cloud-publish.yaml
@@ -47,7 +47,7 @@ jobs:
                   version: 9
             - uses: actions/setup-node@v4
               with:
-                  node-version: "20"
+                  node-version: "22"
             - name: Install stable toolchain
               uses: actions-rust-lang/setup-rust-toolchain@v1
               with:

--- a/.github/workflows/cloud-qa.yaml
+++ b/.github/workflows/cloud-qa.yaml
@@ -47,7 +47,7 @@ jobs:
                   version: 9
             - uses: actions/setup-node@v4
               with:
-                  node-version: "20"
+                  node-version: "22"
             - name: Install stable toolchain
               uses: actions-rust-lang/setup-rust-toolchain@v1
               with:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "prepare": "husky"
     },
     "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
     },
     "jest": {
         "preset": "ts-jest",


### PR DESCRIPTION
Bumping the node version in CI to fix the CrabNebula builds (e.g. see [this failure](https://github.com/meltylabs/chorus/actions/runs/20372799868)).

Tested with this workflow run: https://github.com/meltylabs/chorus/actions/runs/20372961190