### PR TITLE
Rename QA build to Chorus Nightly

### DIFF
--- a/src-tauri/tauri.qa.conf.json
+++ b/src-tauri/tauri.qa.conf.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schema.tauri.app/config/2.0.2",
-    "productName": "Chorus",
+    "productName": "Chorus Nightly",
     "version": "0.14.1",
     "identifier": "sh.chorus.app.qa",
     "build": {
@@ -13,7 +13,7 @@
         "macOSPrivateApi": true,
         "windows": [
             {
-                "title": "Chorus QA",
+                "title": "Chorus Nightly",
                 "label": "main",
                 "titleBarStyle": "Overlay",
                 "url": "/",


### PR DESCRIPTION
Renames the QA build product name and window title to "Chorus Nightly" instead of "Chorus"/"Chorus QA" to give it distinct branding. The QA build already had a separate bundle identifier (sh.chorus.app.qa) and icons, and now has a distinct product name as well.

## Test plan
- [ ] Build the QA app using `pnpm tauri:qa`
- [ ] Verify the app appears as "Chorus Nightly" in the macOS menu bar and Dock
- [ ] Verify the window title bar shows "Chorus Nightly"
- [ ] Verify the QA build still updates correctly via the `?channel=qa` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)