### PR TITLE
Display direct provider models in model picker

### DIFF
--- a/src/ui/components/ManageModelsBox.tsx
+++ b/src/ui/components/ManageModelsBox.tsx
@@ -465,10 +465,32 @@ export function ManageModelsBox({
             (m) => getProviderName(m.modelId) === "openrouter",
         );
 
+        // Direct provider models grouped by provider
+        const directProviders = [
+            "anthropic",
+            "openai",
+            "google",
+            "perplexity",
+            "grok",
+        ] as const;
+
+        const directByProvider = Object.fromEntries(
+            directProviders.map((provider) => [
+                provider,
+                filterBySearch(
+                    systemModels.filter(
+                        (m) => getProviderName(m.modelId) === provider,
+                    ),
+                    searchTerms,
+                ),
+            ]),
+        ) as Record<(typeof directProviders)[number], ModelConfig[]>;
+
         return {
             custom: filterBySearch(userModels, searchTerms),
             local: filterBySearch(localModels, searchTerms),
             openrouter: filterBySearch(openrouterModels, searchTerms),
+            directByProvider,
         };
     }, [modelConfigs.data, searchQuery]);
 
@@ -684,6 +706,63 @@ export function ManageModelsBox({
                                     </div>
                                 ) : undefined
                             }
+                        />
+                    )}
+
+                    {/* Direct Provider Models (Anthropic, OpenAI, Google, etc.) */}
+                    {modelGroups.directByProvider.anthropic.length > 0 && (
+                        <ModelGroup
+                            heading="Anthropic"
+                            models={modelGroups.directByProvider.anthropic}
+                            checkedModelConfigIds={checkedModelConfigIds}
+                            mode={mode}
+                            onToggleModelConfig={handleToggleModelConfig}
+                            onAddApiKey={handleAddApiKey}
+                            groupId="anthropic"
+                        />
+                    )}
+                    {modelGroups.directByProvider.openai.length > 0 && (
+                        <ModelGroup
+                            heading="OpenAI"
+                            models={modelGroups.directByProvider.openai}
+                            checkedModelConfigIds={checkedModelConfigIds}
+                            mode={mode}
+                            onToggleModelConfig={handleToggleModelConfig}
+                            onAddApiKey={handleAddApiKey}
+                            groupId="openai"
+                        />
+                    )}
+                    {modelGroups.directByProvider.google.length > 0 && (
+                        <ModelGroup
+                            heading="Google"
+                            models={modelGroups.directByProvider.google}
+                            checkedModelConfigIds={checkedModelConfigIds}
+                            mode={mode}
+                            onToggleModelConfig={handleToggleModelConfig}
+                            onAddApiKey={handleAddApiKey}
+                            groupId="google"
+                        />
+                    )}
+                    {modelGroups.directByProvider.grok.length > 0 && (
+                        <ModelGroup
+                            heading="Grok"
+                            models={modelGroups.directByProvider.grok}
+                            checkedModelConfigIds={checkedModelConfigIds}
+                            mode={mode}
+                            onToggleModelConfig={handleToggleModelConfig}
+                            onAddApiKey={handleAddApiKey}
+                            groupId="grok"
+                        />
+                    )}
+                    {modelGroups.directByProvider.perplexity.length > 0 && (
+                        <ModelGroup
+                            heading="Perplexity"
+                            models={modelGroups.directByProvider.perplexity}
+                            checkedModelConfigIds={checkedModelConfigIds}
+                            mode={mode}
+                            onToggleModelConfig={handleToggleModelConfig}
+                            onAddApiKey={handleAddApiKey}
+                            groupId="perplexity"
                         />
                     )}
 


### PR DESCRIPTION
Adds separate sections in the model picker for Anthropic, OpenAI, Google, Grok, and Perplexity models. Previously these models were stored in the database but never displayed to users.

Models are now grouped by provider (after OpenRouter) so users can easily select from their preferred providers when they have API keys configured.

## Test plan
- [ ] Open model picker and verify direct provider sections appear (Anthropic, OpenAI, Google, Grok, Perplexity)
- [ ] Verify sections only show if models exist for that provider
- [ ] Verify models can be selected after API keys are configured
- [ ] Verify "Add API Key" button appears for providers without configured keys
- [ ] Verify search works across direct provider models

by-claude