### PR TITLE
Fix TypeScript error with RenderParameters canvas property

### DIFF
--- a/src/core/chorus/AttachmentsHelpers.ts
+++ b/src/core/chorus/AttachmentsHelpers.ts
@@ -255,12 +255,8 @@ export async function convertPdfToPng(filePath: string): Promise<string[]> {
         canvas.width = viewport.width;
 
         // Render PDF page to canvas
-        // Note: pdfjs-dist v5.4+ requires the 'canvas' parameter in RenderParameters
-        // In older versions, only canvasContext was required, but the new API
-        // makes 'canvas' a required property for improved type safety
         await page.render({
-            canvas,
-            canvasContext: context,
+            canvas: canvas,
             viewport: viewport,
         }).promise;
 


### PR DESCRIPTION
Fixes the TypeScript compilation error in `convertPdfToPng` function.

Updated PDF rendering to use the `canvas` parameter instead of `canvasContext`, which is the required API per pdfjs-dist type definitions. The `canvasContext` was previously passed but is not required when using the canvas parameter directly.

**Test Plan:**
- [x] TypeScript compilation passes without errors
- [x] PDF attachment conversion continues to work as expected