### PR TITLE
Add Kimi (Moonshot AI) provider and models

### DIFF
--- a/docs/provider-architecture-refactor.md
+++ b/docs/provider-architecture-refactor.md
@@ -1,0 +1,235 @@
+# Provider Architecture Refactor Plan
+
+## Current State (Problems)
+
+Adding a new model provider to Chorus currently requires changes in **6+ different places**:
+
+1. **`src/core/chorus/Models.ts`**
+   - Add to `ProviderName` type union
+   - Add to `ApiKeys` type
+   - Add case to `getProvider()` switch statement
+   - Add to `CONTEXT_LIMIT_PATTERNS`
+
+2. **`src/core/utilities/ProxyUtils.ts`**
+   - Add to `PROVIDER_TO_API_KEY` mapping
+   - Add to `PROVIDER_DISPLAY_NAMES` mapping
+
+3. **`src/ui/components/ui/provider-logo.tsx`**
+   - Add case to `getLogoComponent()` switch statement
+
+4. **`src/ui/components/ApiKeysForm.tsx`**
+   - Add to hardcoded `providers` array
+
+5. **`src-tauri/src/migrations.rs`**
+   - Add SQL `INSERT` statements for each model (hardcoded)
+
+6. **`src/core/chorus/ModelProviders/Provider*.ts`**
+   - Create a new provider implementation file
+
+### Additional Issues
+
+- **Hardcoded models**: Models are defined in database migrations, requiring new migrations every time a model is added or deprecated
+- **No dynamic model discovery**: Most providers have `/v1/models` endpoints that could be used to fetch available models
+- **Scattered configuration**: Provider metadata (name, logo, API key URL, base URL) is spread across multiple files
+- **Inconsistent patterns**: Some providers (OpenRouter, Ollama, LM Studio) have dynamic model fetching, while others (Anthropic, OpenAI, Google) are fully hardcoded
+
+## Proposed Solution
+
+### 1. Provider Registry
+
+Create a single source of truth for provider configuration:
+
+```typescript
+// src/core/chorus/providers/registry.ts
+
+interface ProviderConfig {
+  id: string;                          // e.g., "kimi", "anthropic"
+  displayName: string;                 // e.g., "Moonshot AI (Kimi)"
+  apiKeyField: string;                 // field name in ApiKeys type
+  apiKeyPlaceholder: string;           // e.g., "sk-..."
+  apiKeyUrl: string;                   // URL to get API key
+  baseUrl: string;                     // API base URL
+  logo: ProviderLogo;                  // logo configuration
+  contextLimitPattern: string;         // error pattern for context limits
+  supportsModelDiscovery: boolean;     // whether /v1/models is available
+  defaultModels?: ModelDefinition[];   // fallback if discovery unavailable
+  providerClass: new () => IProvider;  // provider implementation class
+}
+
+const PROVIDER_REGISTRY: Record<string, ProviderConfig> = {
+  kimi: {
+    id: "kimi",
+    displayName: "Moonshot AI (Kimi)",
+    apiKeyField: "kimi",
+    apiKeyPlaceholder: "sk-...",
+    apiKeyUrl: "https://platform.moonshot.ai/console/api-keys",
+    baseUrl: "https://api.moonshot.ai/v1",
+    logo: { type: "svg", path: "/kimi.svg" },
+    contextLimitPattern: "context length",
+    supportsModelDiscovery: true,
+    providerClass: ProviderKimi,
+  },
+  // ... other providers
+};
+```
+
+### 2. Dynamic Model Discovery
+
+Implement a unified model discovery system:
+
+```typescript
+// src/core/chorus/providers/modelDiscovery.ts
+
+interface ModelDiscoveryResult {
+  models: Model[];
+  source: "api" | "fallback" | "cache";
+}
+
+async function discoverModels(providerId: string): Promise<ModelDiscoveryResult> {
+  const config = PROVIDER_REGISTRY[providerId];
+  
+  if (config.supportsModelDiscovery) {
+    try {
+      // Most providers use OpenAI-compatible /v1/models endpoint
+      const models = await fetchModelsFromApi(config);
+      await cacheModels(providerId, models);
+      return { models, source: "api" };
+    } catch (error) {
+      // Fall back to cached or default models
+      const cached = await getCachedModels(providerId);
+      if (cached) return { models: cached, source: "cache" };
+    }
+  }
+  
+  return { models: config.defaultModels || [], source: "fallback" };
+}
+```
+
+### 3. Base Provider Class
+
+Create a base class for OpenAI-compatible providers (most providers use this format):
+
+```typescript
+// src/core/chorus/ModelProviders/BaseOpenAICompatibleProvider.ts
+
+export class BaseOpenAICompatibleProvider implements IProvider {
+  constructor(
+    protected config: ProviderConfig,
+    protected options?: ProviderOptions
+  ) {}
+
+  async streamResponse(params: StreamResponseParams): Promise<void> {
+    const { apiKeys, modelConfig, ... } = params;
+    
+    const client = new OpenAI({
+      baseURL: this.config.baseUrl,
+      apiKey: apiKeys[this.config.apiKeyField],
+      dangerouslyAllowBrowser: true,
+    });
+    
+    // Common streaming logic...
+  }
+}
+
+// Provider-specific implementations only override what's different
+export class ProviderKimi extends BaseOpenAICompatibleProvider {
+  constructor() {
+    super(PROVIDER_REGISTRY.kimi);
+  }
+  
+  // Override only if needed for provider-specific behavior
+}
+```
+
+### 4. Auto-generated UI Components
+
+Generate API key forms and provider logos from the registry:
+
+```typescript
+// src/ui/components/ApiKeysForm.tsx
+
+function ApiKeysForm({ apiKeys, onApiKeyChange }) {
+  // Generate from registry instead of hardcoding
+  const providers = Object.values(PROVIDER_REGISTRY)
+    .filter(p => p.apiKeyField) // exclude local providers
+    .map(p => ({
+      id: p.id,
+      name: p.displayName,
+      placeholder: p.apiKeyPlaceholder,
+      url: p.apiKeyUrl,
+    }));
+  
+  // ... rest of component
+}
+```
+
+## Migration Strategy
+
+### Phase 1: Create Registry (Non-breaking)
+1. Create `PROVIDER_REGISTRY` with current providers
+2. Refactor utility functions to read from registry
+3. Keep existing code working
+
+### Phase 2: Implement Model Discovery
+1. Add model discovery for providers that support it
+2. Cache discovered models in SQLite
+3. Add periodic refresh mechanism
+
+### Phase 3: Consolidate Provider Implementations
+1. Create `BaseOpenAICompatibleProvider`
+2. Migrate simple providers (Kimi, Grok, Perplexity) to use base class
+3. Keep complex providers (Anthropic, Google) as custom implementations
+
+### Phase 4: UI Refactor
+1. Generate `ApiKeysForm` from registry
+2. Generate provider logos from registry
+3. Remove hardcoded provider lists
+
+### Phase 5: Remove Hardcoded Models
+1. Remove model INSERT statements from migrations
+2. Implement model discovery for all providers
+3. Add admin UI for managing model visibility
+
+## Benefits After Refactor
+
+- **Adding a new provider**: Single file with `ProviderConfig` + optional custom `IProvider`
+- **Adding a new model**: Automatic via API discovery, or single config entry
+- **Consistent behavior**: All providers follow same patterns
+- **Easier testing**: Provider configs can be mocked easily
+- **Better maintainability**: Single source of truth for provider metadata
+
+## Files to Create/Modify
+
+### New Files
+- `src/core/chorus/providers/registry.ts`
+- `src/core/chorus/providers/modelDiscovery.ts`
+- `src/core/chorus/ModelProviders/BaseOpenAICompatibleProvider.ts`
+
+### Files to Modify
+- `src/core/chorus/Models.ts` - Use registry instead of switch statements
+- `src/core/utilities/ProxyUtils.ts` - Use registry
+- `src/ui/components/ui/provider-logo.tsx` - Use registry
+- `src/ui/components/ApiKeysForm.tsx` - Use registry
+
+### Files to Eventually Remove/Simplify
+- Individual provider files that use base class
+- Hardcoded model migrations in `migrations.rs`
+
+## Timeline Estimate
+
+- Phase 1: 1-2 days
+- Phase 2: 2-3 days
+- Phase 3: 2-3 days
+- Phase 4: 1-2 days
+- Phase 5: 2-3 days
+
+**Total: ~2 weeks of focused work**
+
+## Related Issues
+
+<!-- Link to GitHub issues when created -->
+
+---
+
+*Document created: January 2025*
+*Status: Proposed*

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -34,7 +34,7 @@ pub fn migrations() -> Vec<Migration> {
             sql: r#"
                 -- Delete any rows with null ids
                 DELETE FROM chats WHERE id IS NULL;
-                
+
                 -- Create new tables with NOT NULL constraint
                 CREATE TABLE chats_new (
                     id TEXT NOT NULL PRIMARY KEY,
@@ -69,7 +69,7 @@ pub fn migrations() -> Vec<Migration> {
                 );
 
                 -- Copy existing data
-                INSERT INTO messages_new 
+                INSERT INTO messages_new
                 SELECT * FROM messages;
 
                 -- Drop old table and rename new one
@@ -96,7 +96,7 @@ pub fn migrations() -> Vec<Migration> {
 
                 -- Insert default models
                 INSERT INTO models (id, name, type, api_key, model_id, system_prompt, request_template, is_enabled) VALUES
-                ('claude', 'Claude 3.5 Sonnet', 'anthropic', NULL, 'claude-3-5-sonnet-20241022', 'You are a helpful AI assistant. Please provide clear and concise responses.', 
+                ('claude', 'Claude 3.5 Sonnet', 'anthropic', NULL, 'claude-3-5-sonnet-20241022', 'You are a helpful AI assistant. Please provide clear and concise responses.',
                     '{
                         "model": "claude-3-5-sonnet-20241022",
                         "max_tokens": 8192,
@@ -164,12 +164,12 @@ pub fn migrations() -> Vec<Migration> {
             sql: "
                 -- Add updated_at column to chats table
                 ALTER TABLE chats ADD COLUMN updated_at DATETIME;
-                
+
                 -- Initialize updated_at with created_at for existing rows
                 UPDATE chats SET updated_at = created_at WHERE updated_at IS NULL;
-                
+
                 -- Create trigger to automatically update updated_at
-                CREATE TRIGGER IF NOT EXISTS update_chats_timestamp 
+                CREATE TRIGGER IF NOT EXISTS update_chats_timestamp
                 AFTER UPDATE ON chats
                 BEGIN
                     UPDATE chats SET updated_at = CURRENT_TIMESTAMP
@@ -177,7 +177,7 @@ pub fn migrations() -> Vec<Migration> {
                 END;
 
                 -- Also update updated_at when a new message is added
-                CREATE TRIGGER IF NOT EXISTS update_chats_timestamp_on_message 
+                CREATE TRIGGER IF NOT EXISTS update_chats_timestamp_on_message
                 AFTER INSERT ON messages
                 BEGIN
                     UPDATE chats SET updated_at = CURRENT_TIMESTAMP
@@ -192,7 +192,7 @@ pub fn migrations() -> Vec<Migration> {
             sql: "
                 -- Add pinned column to chats table with NOT NULL constraint and default to false
                 ALTER TABLE chats ADD COLUMN pinned BOOLEAN NOT NULL DEFAULT 0;
-                
+
                 -- Create index for faster querying of pinned chats
                 CREATE INDEX IF NOT EXISTS idx_chats_pinned ON chats(pinned);
             ",
@@ -289,8 +289,8 @@ pub fn migrations() -> Vec<Migration> {
             sql: r#"
                 -- Insert new Gemini Thinking model
                 INSERT INTO models (
-                    id, name, type, api_key, model_id, 
-                    system_prompt, request_template, 
+                    id, name, type, api_key, model_id,
+                    system_prompt, request_template,
                     is_enabled, display_order, is_selected, short_name
                 ) VALUES (
                     'gemini-thinking',
@@ -312,7 +312,7 @@ pub fn migrations() -> Vec<Migration> {
                 );
 
                 -- Update display order of other models if needed
-                UPDATE models 
+                UPDATE models
                 SET display_order = CASE id
                     WHEN 'claude' THEN 1
                     WHEN 'gpt' THEN 2
@@ -378,12 +378,12 @@ pub fn migrations() -> Vec<Migration> {
             description: "set default enabled state for Gemini and Perplexity models",
             sql: r#"
                 -- Enable Gemini models
-                UPDATE models SET is_enabled = 1 
-                WHERE type = 'gemini' 
+                UPDATE models SET is_enabled = 1
+                WHERE type = 'gemini'
                 AND model_id IN ('gemini-2.0-flash-exp', 'gemini-2.0-flash-thinking-exp');
 
                 -- Enable Perplexity models
-                UPDATE models SET is_enabled = 1 
+                UPDATE models SET is_enabled = 1
                 WHERE type = 'perplexity';
             "#,
             kind: MigrationKind::Up,
@@ -393,11 +393,11 @@ pub fn migrations() -> Vec<Migration> {
             description: "set Gemini Flash 2.0 as selected instead of Thinking",
             sql: r#"
                 -- Deselect Gemini Flash Thinking
-                UPDATE models SET is_selected = 0 
+                UPDATE models SET is_selected = 0
                 WHERE model_id = 'gemini-2.0-flash-thinking-exp';
 
                 -- Select Gemini Flash 2.0
-                UPDATE models SET is_selected = 1 
+                UPDATE models SET is_selected = 1
                 WHERE model_id = 'gemini-2.0-flash-exp';
             "#,
             kind: MigrationKind::Up,
@@ -623,7 +623,7 @@ JOIN temp_message_sets ms
                 ALTER TABLE models ADD COLUMN server_url TEXT;
 
                 -- Set default server URL for LM Studio models
-                UPDATE models 
+                UPDATE models
                 SET server_url = 'http://localhost:1234/v1'
                 WHERE type = 'lmstudio';
             "#,
@@ -640,7 +640,7 @@ JOIN temp_message_sets ms
                 BEGIN
                     -- First delete all messages associated with the chat
                     DELETE FROM messages WHERE chat_id = OLD.id;
-                    
+
                     -- Then delete all message_sets associated with the chat
                     DELETE FROM message_sets WHERE chat_id = OLD.id;
                 END;
@@ -833,7 +833,7 @@ JOIN temp_message_sets ms
                         UNION ALL
                         SELECT 'webpage'
                         WHERE NOT EXISTS (
-                            SELECT 1 
+                            SELECT 1
                             FROM json_each(supported_attachment_types)
                             WHERE value = 'webpage'
                         )
@@ -917,7 +917,7 @@ JOIN temp_message_sets ms
             kind: MigrationKind::Up,
             sql: r#"
                 -- Update the display name of the old Perplexity model
-                UPDATE model_configs 
+                UPDATE model_configs
                 SET display_name = 'Perplexity Llama 3.1 (Deprecated)'
                 WHERE id = 'perplexity::llama-3.1-sonar-huge-128k-online';
             "#,
@@ -931,7 +931,7 @@ JOIN temp_message_sets ms
                 ALTER TABLE models ADD COLUMN is_deprecated BOOLEAN NOT NULL DEFAULT 0;
 
                 -- Mark the old Perplexity model as deprecated
-                UPDATE models 
+                UPDATE models
                 SET is_deprecated = 1
                 WHERE id = 'perplexity::llama-3.1-sonar-huge-128k-online';
             "#,
@@ -1012,7 +1012,7 @@ JOIN temp_message_sets ms
                     ('system', 'google::gemini-2.0-flash', 'google::gemini-2.0-flash', 'Gemini 2.0 Flash', '', 0);
 
                 -- Update the display name of the experimental model
-                UPDATE models 
+                UPDATE models
                 SET display_name = 'Gemini 2.0 Flash (Experimental)'
                 WHERE id = 'google::gemini-2.0-flash-exp';
 
@@ -1097,15 +1097,15 @@ If the user has vision mode enabled, whenever they send a message, the system wi
                 -- Update selected_model_config_ids to use new gemini flash model instead of experimental version
                 UPDATE app_metadata
                 SET value = json_array(
-                    CASE 
+                    CASE
                         WHEN json_extract(value, '$[0]') = 'google::gemini-2.0-flash-exp' THEN 'google::gemini-2.0-flash'
                         ELSE json_extract(value, '$[0]')
                     END,
-                    CASE 
+                    CASE
                         WHEN json_extract(value, '$[1]') = 'google::gemini-2.0-flash-exp' THEN 'google::gemini-2.0-flash'
                         ELSE json_extract(value, '$[1]')
                     END,
-                    CASE 
+                    CASE
                         WHEN json_extract(value, '$[2]') = 'google::gemini-2.0-flash-exp' THEN 'google::gemini-2.0-flash'
                         ELSE json_extract(value, '$[2]')
                     END
@@ -1148,11 +1148,11 @@ If the user has vision mode enabled, whenever they send a message, the system wi
                     INSERT OR REPLACE INTO projects (id, name) VALUES ('quick-chat', 'Ambient Chat');
 
                 -- add project_id column to chats table
-                
+
                     ALTER TABLE chats ADD COLUMN project_id TEXT NOT NULL DEFAULT 'default';
 
                     UPDATE chats SET project_id = 'quick-chat' WHERE quick_chat = 1;
-                
+
                     -- On insert make sure the referenced project exists.
                     CREATE TRIGGER verify_chats_project_id_insert
                     BEFORE INSERT ON chats
@@ -1210,12 +1210,12 @@ If the user has vision mode enabled, whenever they send a message, the system wi
                 AFTER INSERT ON messages
                 FOR EACH ROW
                 BEGIN
-                    UPDATE messages 
+                    UPDATE messages
                     SET selected = 1
                     WHERE id = NEW.id
                     AND (
-                        SELECT COUNT(*) 
-                        FROM messages 
+                        SELECT COUNT(*)
+                        FROM messages
                         WHERE message_set_id = NEW.message_set_id
                     ) = 1;
                 END;
@@ -1227,7 +1227,7 @@ If the user has vision mode enabled, whenever they send a message, the system wi
                 FOR EACH ROW
                 WHEN OLD.selected = 1
                 BEGIN
-                    UPDATE messages 
+                    UPDATE messages
                     SET selected = 1
                     WHERE id = (
                         SELECT id
@@ -1572,7 +1572,7 @@ If the user has vision mode enabled, whenever they send a message, the system wi
             kind: MigrationKind::Up,
             sql: r#"
                 -- Update quick_chat_model_config_id to Ambient Claude for everyone
-                INSERT OR REPLACE INTO app_metadata (key, value) 
+                INSERT OR REPLACE INTO app_metadata (key, value)
                 VALUES ('quick_chat_model_config_id', '24711c64-725c-4bdd-b5eb-65fe1dbfcde8');
             "#,
         },
@@ -1655,7 +1655,7 @@ You have full access to bash commands on the user''s computer. If you write a ba
             description: "reset quick chat model config to claude 3.7 sonnet, since we're getting rid of the picker",
             kind: MigrationKind::Up,
             sql: r#"
-                INSERT OR REPLACE INTO app_metadata (key, value) 
+                INSERT OR REPLACE INTO app_metadata (key, value)
                 VALUES ('quick_chat_model_config_id', '24711c64-725c-4bdd-b5eb-65fe1dbfcde8');
             "#,
         },
@@ -1697,11 +1697,11 @@ You have full access to bash commands on the user''s computer. If you write a ba
                 WITH RECURSIVE MessageHierarchy AS (
                     -- Base case: get root messages (no parent)
                     SELECT id, 0 as level
-                    FROM message_sets 
+                    FROM message_sets
                     WHERE parent_id IS NULL
-                    
+
                     UNION ALL
-                    
+
                     -- Recursive case: get children
                     SELECT m.id, mh.level + 1
                     FROM message_sets m
@@ -1767,7 +1767,7 @@ You have full access to bash commands on the user''''s computer. If you write a 
                     0);
 
                 -- Update quick_chat_model_config_id to Ambient Gemini
-                INSERT OR REPLACE INTO app_metadata (key, value) 
+                INSERT OR REPLACE INTO app_metadata (key, value)
                 VALUES ('quick_chat_model_config_id', 'google::ambient-gemini-2.5-pro-preview-03-25');
             "#,
         },
@@ -1972,7 +1972,7 @@ You have full access to bash commands on the user''''s computer. If you write a 
             sql: r#"
                 -- Add is_new_chat column to chats table
                 ALTER TABLE chats ADD COLUMN is_new_chat BOOLEAN NOT NULL DEFAULT 0;
-                
+
                 -- Create trigger to automatically set is_new_chat to false when messages are added
                 CREATE TRIGGER set_chat_not_new_on_message
                 AFTER INSERT ON messages
@@ -1980,15 +1980,15 @@ You have full access to bash commands on the user''''s computer. If you write a 
                     UPDATE chats SET is_new_chat = 0
                     WHERE id = NEW.chat_id;
                 END;
-                
+
                 -- Create index for faster querying of new chats
                 CREATE INDEX IF NOT EXISTS idx_chats_is_new_chat ON chats(is_new_chat);
-                
+
                 -- Enforce that there is only one new chat for each type
                 CREATE UNIQUE INDEX one_new_chat ON chats(is_new_chat, quick_chat) WHERE is_new_chat = 1 AND quick_chat = 0;
                 CREATE UNIQUE INDEX one_new_quick_chat ON chats(is_new_chat, quick_chat) WHERE is_new_chat = 1 AND quick_chat = 1;
-                
-                -- Delete old "empty" chats with no messages 
+
+                -- Delete old "empty" chats with no messages
                 DELETE FROM chats WHERE id NOT IN (SELECT DISTINCT chat_id FROM messages);
             "#,
         },
@@ -2001,11 +2001,11 @@ You have full access to bash commands on the user''''s computer. If you write a 
                 DROP TRIGGER IF EXISTS update_chats_timestamp;
 
                 -- Recreate the update_chats_timestamp_on_message trigger
-                -- This got erased by the messages table rename in Migration 17 
+                -- This got erased by the messages table rename in Migration 17
                 -- Drop the trigger first if it exists to ensure clean recreation
                 DROP TRIGGER IF EXISTS update_chats_timestamp_on_message;
 
-                CREATE TRIGGER update_chats_timestamp_on_message 
+                CREATE TRIGGER update_chats_timestamp_on_message
                 AFTER INSERT ON messages
                 BEGIN
                     UPDATE chats SET updated_at = CURRENT_TIMESTAMP
@@ -2222,7 +2222,7 @@ You have full access to bash commands on the user''''s computer. If you write a 
             kind: MigrationKind::Up,
             sql: r#"
                 ALTER TABLE model_configs ADD COLUMN new_until DATETIME;
-                
+
                 -- Set new_until for deepseek r1 0528 to June 10
                 UPDATE model_configs
                 SET new_until = '2025-06-10 00:00:00'
@@ -2286,7 +2286,7 @@ You have full access to bash commands on the user''''s computer. If you write a 
                     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
                     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
                 );
-                
+
                 -- Create index on chat_id for faster lookups
                 CREATE INDEX idx_saved_model_configs_chats_chat_id ON saved_model_configs_chats(chat_id);
             "#,
@@ -2306,7 +2306,7 @@ You have full access to bash commands on the user''''s computer. If you write a 
             sql: r#"
                 -- Add gc_prototype_chat column to chats table with default value of 0 (not a group chat)
                 ALTER TABLE chats ADD COLUMN gc_prototype_chat BOOLEAN NOT NULL DEFAULT 0;
-                
+
                 -- Create gc_prototype_messages table for group chat messages
                 CREATE TABLE gc_prototype_messages (
                     chat_id TEXT NOT NULL,
@@ -2320,12 +2320,12 @@ You have full access to bash commands on the user''''s computer. If you write a 
                     promoted_from_message_id TEXT,
                     PRIMARY KEY (chat_id, id)
                 );
-                
+
                 -- Create indexes for gc_prototype_messages
                 CREATE INDEX idx_gc_prototype_messages_chat_created ON gc_prototype_messages(chat_id, created_at);
                 CREATE INDEX idx_gc_prototype_messages_thread_root ON gc_prototype_messages(thread_root_message_id);
                 CREATE INDEX idx_gc_prototype_messages_promoted_from ON gc_prototype_messages(promoted_from_message_id);
-                
+
                 -- Create gc_prototype_conductors table for group chat conductor feature
                 CREATE TABLE gc_prototype_conductors (
                     chat_id TEXT NOT NULL,
@@ -2336,7 +2336,7 @@ You have full access to bash commands on the user''''s computer. If you write a 
                     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
                     PRIMARY KEY (chat_id, scope_id)
                 );
-                
+
                 -- Create index for efficient lookups of active conductors
                 CREATE INDEX idx_gc_prototype_conductors_active ON gc_prototype_conductors(chat_id, is_active);
             "#,
@@ -2372,7 +2372,7 @@ You have full access to bash commands on the user''''s computer. If you write a 
                 );
 
                 -- Add default permission settings to custom_toolsets
-                ALTER TABLE custom_toolsets ADD COLUMN default_permission TEXT NOT NULL DEFAULT 'ask' 
+                ALTER TABLE custom_toolsets ADD COLUMN default_permission TEXT NOT NULL DEFAULT 'ask'
                     CHECK (default_permission IN ('always_allow', 'always_deny', 'ask'));
             "#,
         },
@@ -2552,6 +2552,28 @@ You have full access to bash commands on the user''''s computer. If you write a 
             sql: r#"
                 UPDATE chats SET total_cost_usd = 0.0 WHERE total_cost_usd IS NULL;
                 UPDATE projects SET total_cost_usd = 0.0 WHERE total_cost_usd IS NULL;
+            "#,
+        },
+        Migration {
+            version: 139,
+            description: "add Kimi (Moonshot AI) models",
+            kind: MigrationKind::Up,
+            sql: r#"
+                -- Add Kimi K2 model (flagship model, 256k context)
+                INSERT OR REPLACE INTO models (id, display_name, is_enabled, supported_attachment_types) VALUES
+                    ('kimi::kimi-k2', 'Kimi K2', 1, '["text", "image", "webpage"]');
+
+                -- Add default config for Kimi K2
+                INSERT OR REPLACE INTO model_configs (author, id, model_id, display_name, system_prompt, is_default) VALUES
+                    ('system', 'kimi::kimi-k2', 'kimi::kimi-k2', 'Kimi K2', '', 0);
+
+                -- Add Kimi K2 Thinking model (reasoning variant)
+                INSERT OR REPLACE INTO models (id, display_name, is_enabled, supported_attachment_types) VALUES
+                    ('kimi::kimi-k2-thinking', 'Kimi K2 Thinking', 1, '["text", "image", "webpage"]');
+
+                -- Add default config for Kimi K2 Thinking
+                INSERT OR REPLACE INTO model_configs (author, id, model_id, display_name, system_prompt, is_default) VALUES
+                    ('system', 'kimi::kimi-k2-thinking', 'kimi::kimi-k2-thinking', 'Kimi K2 Thinking', '', 0);
             "#,
         },
     ];

--- a/src/core/chorus/ModelProviders/ProviderKimi.ts
+++ b/src/core/chorus/ModelProviders/ProviderKimi.ts
@@ -1,0 +1,208 @@
+import OpenAI from "openai";
+import { StreamResponseParams } from "../Models";
+import { IProvider } from "./IProvider";
+import { canProceedWithProvider } from "@core/utilities/ProxyUtils";
+import OpenAICompletionsAPIUtils from "@core/chorus/OpenAICompletionsAPIUtils";
+
+export class ProviderKimi implements IProvider {
+    async streamResponse({
+        modelConfig,
+        llmConversation,
+        apiKeys,
+        onChunk,
+        onComplete,
+        onError,
+        additionalHeaders,
+        tools,
+        customBaseUrl,
+    }: StreamResponseParams) {
+        const modelName = modelConfig.modelId.split("::")[1];
+
+        // Validate supported models
+        const supportedModels = [
+            "kimi-k2",
+            "kimi-k2-thinking",
+            "moonshot-v1-8k",
+            "moonshot-v1-32k",
+            "moonshot-v1-128k",
+        ];
+
+        if (!supportedModels.includes(modelName)) {
+            throw new Error(`Unsupported Kimi model: ${modelName}`);
+        }
+
+        const { canProceed, reason } = canProceedWithProvider("kimi", apiKeys);
+
+        if (!canProceed) {
+            throw new Error(
+                reason || "Please add your Moonshot AI API key in Settings.",
+            );
+        }
+
+        const baseURL = customBaseUrl || "https://api.moonshot.ai/v1";
+
+        const client = new OpenAI({
+            baseURL,
+            apiKey: apiKeys.kimi,
+            defaultHeaders: {
+                ...(additionalHeaders ?? {}),
+            },
+            dangerouslyAllowBrowser: true,
+        });
+
+        // Kimi supports images for the k2 models
+        const imageSupport =
+            modelName === "kimi-k2" || modelName === "kimi-k2-thinking";
+
+        // Kimi supports tool calls (but tool_choice doesn't support "required")
+        const functionSupport = true;
+
+        let messages: OpenAI.ChatCompletionMessageParam[] =
+            await OpenAICompletionsAPIUtils.convertConversation(
+                llmConversation,
+                {
+                    imageSupport,
+                    functionSupport,
+                },
+            );
+
+        // Add system prompt if provided
+        if (modelConfig.systemPrompt) {
+            messages = [
+                {
+                    role: "system",
+                    content: modelConfig.systemPrompt,
+                },
+                ...messages,
+            ];
+        }
+
+        // Convert tools to OpenAI format
+        const openaiTools: OpenAI.ChatCompletionTool[] | undefined =
+            tools?.map((tool) => ({
+                type: "function" as const,
+                function: {
+                    name: `${tool.toolsetName}__${tool.name}`,
+                    description: tool.description,
+                    parameters: tool.inputSchema,
+                },
+            }));
+
+        const streamParams: OpenAI.ChatCompletionCreateParamsStreaming = {
+            model: modelName,
+            messages,
+            stream: true,
+            // Kimi doesn't support tool_choice: "required", only "auto" or "none"
+            ...(openaiTools &&
+                openaiTools.length > 0 && {
+                    tools: openaiTools,
+                    tool_choice: "auto" as const,
+                }),
+        };
+
+        try {
+            const stream = await client.chat.completions.create(streamParams);
+
+            let fullContent = "";
+            const toolCalls: Array<{
+                id: string;
+                name: string;
+                arguments: string;
+            }> = [];
+
+            for await (const chunk of stream) {
+                const delta = chunk.choices[0]?.delta;
+
+                // Handle content chunks
+                if (delta?.content) {
+                    fullContent += delta.content;
+                    onChunk(delta.content);
+                }
+
+                // Handle tool call chunks
+                if (delta?.tool_calls) {
+                    for (const toolCallDelta of delta.tool_calls) {
+                        const index = toolCallDelta.index;
+
+                        // Initialize tool call if needed
+                        if (!toolCalls[index]) {
+                            toolCalls[index] = {
+                                id: toolCallDelta.id || "",
+                                name: toolCallDelta.function?.name || "",
+                                arguments: "",
+                            };
+                        }
+
+                        // Accumulate tool call data
+                        if (toolCallDelta.id) {
+                            toolCalls[index].id = toolCallDelta.id;
+                        }
+                        if (toolCallDelta.function?.name) {
+                            toolCalls[index].name = toolCallDelta.function.name;
+                        }
+                        if (toolCallDelta.function?.arguments) {
+                            toolCalls[index].arguments +=
+                                toolCallDelta.function.arguments;
+                        }
+                    }
+                }
+            }
+
+            // Convert tool calls to UserToolCall format
+            const userToolCalls =
+                toolCalls.length > 0
+                    ? toolCalls.map((tc) => {
+                          const [toolsetName, toolName] = tc.name.split("__");
+                          return {
+                              id: tc.id,
+                              toolsetName: toolsetName || "",
+                              toolName: toolName || tc.name,
+                              input: tc.arguments,
+                          };
+                      })
+                    : undefined;
+
+            await onComplete(
+                fullContent || undefined,
+                userToolCalls,
+                undefined,
+            );
+        } catch (error: unknown) {
+            console.error("[ProviderKimi] Error:", error);
+
+            if (error instanceof Error) {
+                // Handle specific Kimi API errors
+                const errorMessage = error.message;
+
+                if (
+                    errorMessage.includes("context_length_exceeded") ||
+                    errorMessage.includes("maximum context length")
+                ) {
+                    onError(
+                        "The conversation is too long for this model's context window. Please start a new chat or use a model with a larger context window.",
+                    );
+                    return;
+                }
+
+                if (
+                    errorMessage.includes("invalid_api_key") ||
+                    errorMessage.includes("Unauthorized")
+                ) {
+                    onError(
+                        "Invalid Moonshot AI API key. Please check your API key in Settings.",
+                    );
+                    return;
+                }
+
+                if (errorMessage.includes("rate_limit")) {
+                    onError(
+                        "Rate limit exceeded. Please wait a moment and try again.",
+                    );
+                    return;
+                }
+            }
+
+            throw error;
+        }
+    }
+}

--- a/src/core/chorus/Models.ts
+++ b/src/core/chorus/Models.ts
@@ -17,6 +17,7 @@ import { ollamaClient } from "./OllamaClient";
 import { ProviderOllama } from "./ModelProviders/ProviderOllama";
 import { ProviderLMStudio } from "./ModelProviders/ProviderLMStudio";
 import { ProviderGrok } from "./ModelProviders/ProviderGrok";
+import { ProviderKimi } from "./ModelProviders/ProviderKimi";
 import posthog from "posthog-js";
 import { UserTool, UserToolCall, UserToolResult } from "./Toolsets";
 import { Attachment } from "./api/AttachmentsAPI";
@@ -157,6 +158,7 @@ export type ApiKeys = {
     openrouter?: string;
     google?: string;
     grok?: string;
+    kimi?: string;
 };
 
 export type Model = {
@@ -242,6 +244,7 @@ export type ProviderName =
     | "ollama"
     | "lmstudio"
     | "grok"
+    | "kimi"
     | "meta";
 
 /**
@@ -296,6 +299,8 @@ function getProvider(providerName: string): IProvider {
             return new ProviderLMStudio();
         case "grok":
             return new ProviderGrok();
+        case "kimi":
+            return new ProviderKimi();
         default:
             throw new Error(`Unknown provider: ${providerName}`);
     }
@@ -613,6 +618,7 @@ const CONTEXT_LIMIT_PATTERNS: Record<ProviderName, string> = {
     lmstudio: "context window", // best guess
     perplexity: "context window", // best guess
     ollama: "context window", // best guess
+    kimi: "context_length_exceeded",
 };
 
 /**

--- a/src/core/utilities/ProxyUtils.ts
+++ b/src/core/utilities/ProxyUtils.ts
@@ -15,6 +15,7 @@ const PROVIDER_TO_API_KEY: Record<string, keyof ApiKeys> = {
     perplexity: "perplexity",
     openrouter: "openrouter",
     grok: "grok",
+    kimi: "kimi",
 };
 
 /**
@@ -27,6 +28,7 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
     perplexity: "Perplexity",
     openrouter: "OpenRouter",
     grok: "xAI",
+    kimi: "Moonshot AI",
 };
 
 /**

--- a/src/ui/components/ApiKeysForm.tsx
+++ b/src/ui/components/ApiKeysForm.tsx
@@ -57,6 +57,12 @@ export default function ApiKeysForm({
             url: "https://console.x.ai/settings/keys",
         },
         {
+            id: "kimi",
+            name: "Moonshot AI (Kimi)",
+            placeholder: "sk-...",
+            url: "https://platform.moonshot.ai/console/api-keys",
+        },
+        {
             id: "firecrawl",
             name: "Firecrawl",
             placeholder: "fc-...",

--- a/src/ui/components/ui/provider-logo.tsx
+++ b/src/ui/components/ui/provider-logo.tsx
@@ -1,7 +1,7 @@
 import { getProviderName, ProviderName } from "@core/chorus/Models";
 import { OPENROUTER_CUSTOM_PROVIDER_LOGOS } from "@ui/lib/models";
 import { cn } from "@ui/lib/utils";
-import { BoxIcon } from "lucide-react";
+import { BoxIcon, MoonIcon } from "lucide-react";
 import {
     RiAnthropicFill,
     RiOpenaiFill,
@@ -64,6 +64,8 @@ export function ProviderLogo({
                         className="w-4 h-4 dark:invert"
                     />
                 );
+            case "kimi":
+                return <MoonIcon className="w-4 h-4" />;
             case "openrouter":
                 if (modelId && modelId in OPENROUTER_CUSTOM_PROVIDER_LOGOS) {
                     return getLogoComponent(


### PR DESCRIPTION
## Summary
Adds support for Moonshot AI's Kimi models to Chorus.

### New Models
- **Kimi K2**: Flagship model with 1T parameters (32B active), 256k context window
- **Kimi K2 Thinking**: Reasoning variant with extended chain-of-thought capabilities

### Changes
- Added `ProviderKimi.ts` - OpenAI-compatible provider implementation for Moonshot AI
- Added `kimi` to `ProviderName`, `ApiKeys`, and `getProvider()` in `Models.ts`
- Added Kimi to `ProxyUtils.ts` (API key mapping and display name)
- Added Moonshot AI to `ApiKeysForm.tsx` providers list
- Added Kimi provider logo (MoonIcon from lucide-react) to `provider-logo.tsx`
- Added migration 139 for `kimi-k2` and `kimi-k2-thinking` models
- Added future refactor documentation in `docs/provider-architecture-refactor.md`

### API Details
- Base URL: `https://api.moonshot.ai/v1`
- OpenAI-compatible API format
- Supports streaming, tool calls (note: `tool_choice` doesn't support "required")
- Image support for K2 models

### Future Improvements
Added documentation for a proposed provider architecture refactor that would make adding new providers much easier (currently requires changes in 6+ files).

## Test Plan
- [ ] Add a Moonshot AI API key in Settings > API Keys
- [ ] Verify the Kimi K2 model appears in model selection
- [ ] Send a message to Kimi K2 and verify streaming works
- [ ] Test Kimi K2 Thinking model for reasoning tasks
- [ ] Verify tool calls work (e.g., with web search or file tools enabled)
- [ ] Verify error handling for invalid API key
- [ ] Verify existing providers (Anthropic, OpenAI, Google, etc.) still work correctly