### PR TITLE
Enable all OpenRouter models in ambient chat

### DIFF
--- a/src/ui/components/QuickChatModelSelector.tsx
+++ b/src/ui/components/QuickChatModelSelector.tsx
@@ -85,7 +85,8 @@ export function QuickChatModelSelector({
                     config.isEnabled &&
                     !config.id.includes("chorus") &&
                     !config.displayName.includes("Deprecated") &&
-                    ALLOWED_MODEL_IDS_FOR_QUICK_CHAT.includes(config.id) &&
+                    (config.modelId.startsWith("openrouter::") ||
+                        ALLOWED_MODEL_IDS_FOR_QUICK_CHAT.includes(config.id)) &&
                     isModelAllowed(config),
             ) ?? [],
         [modelConfigsQuery, isModelAllowed],


### PR DESCRIPTION
Fixes #17

This PR enables all OpenRouter models (free and paid) to be used in ambient chat by bypassing the `ALLOWED_MODEL_IDS_FOR_QUICK_CHAT` allowlist for any model with an ID starting with `openrouter::`.

## Changes
- Modified `QuickChatModelSelector.tsx` to allow all enabled OpenRouter models in ambient chat
- Added OR condition to check if model ID starts with `openrouter::` before checking the allowlist
- Maintains existing allowlist behavior for all other providers

## Test Plan
- [x] Open ambient chat (Quick Chat)
- [x] Click the model selector dropdown
- [x] Verify that all enabled OpenRouter models now appear in the list (not just the previously allowed ones like Qwen 32B)
- [ ] Select a free OpenRouter model (e.g., `meta-llama/llama-3.2-1b-instruct:free`) and verify it works
- [ ] Select a paid OpenRouter model and verify it works
- [ ] Verify that other providers (Claude, GPT, Gemini) still only show their allowed models
- [ ] Verify that disabled OpenRouter models do not appear in the list
- [ ] Verify that models requiring API keys are properly disabled if no key is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)