### PR TITLE
Fix openrouter stream final chunk

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "chorus",
     "license": "MIT",
     "private": true,
-    "version": "0.14.4",
+    "version": "0.14.5",
     "type": "module",
     "scripts": {
         "tauri": "tauri",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -78,11 +78,36 @@ fn parse_shortcut(shortcut_str: &str) -> Option<Shortcut> {
     }
     println!("Final modifiers: {:?}", modifiers);
 
-    let code = match key_str.to_lowercase().as_str() {
+    let key_lower = key_str.to_lowercase();
+    let code = match key_lower.as_str() {
         "space" => Code::Space,
         "enter" => Code::Enter,
         "tab" => Code::Tab,
         "escape" => Code::Escape,
+        "f1" => Code::F1,
+        "f2" => Code::F2,
+        "f3" => Code::F3,
+        "f4" => Code::F4,
+        "f5" => Code::F5,
+        "f6" => Code::F6,
+        "f7" => Code::F7,
+        "f8" => Code::F8,
+        "f9" => Code::F9,
+        "f10" => Code::F10,
+        "f11" => Code::F11,
+        "f12" => Code::F12,
+        "f13" => Code::F13,
+        "f14" => Code::F14,
+        "f15" => Code::F15,
+        "f16" => Code::F16,
+        "f17" => Code::F17,
+        "f18" => Code::F18,
+        "f19" => Code::F19,
+        "f20" => Code::F20,
+        "f21" => Code::F21,
+        "f22" => Code::F22,
+        "f23" => Code::F23,
+        "f24" => Code::F24,
         c if c.len() == 1 => {
             let ch = c.chars().next()?;
             char_to_code(ch.to_ascii_uppercase())?

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schema.tauri.app/config/2.0.2",
     "productName": "Chorus",
-    "version": "0.14.4",
+    "version": "0.14.5",
     "identifier": "sh.chorus.app",
     "build": {
         "beforeDevCommand": "pnpm vite:dev",

--- a/src-tauri/tauri.dev.conf.json
+++ b/src-tauri/tauri.dev.conf.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schema.tauri.app/config/2.0.2",
     "productName": "Chorus",
-    "version": "0.14.4",
+    "version": "0.14.5",
     "identifier": "sh.chorus.app.dev",
     "build": {
         "beforeDevCommand": "pnpm vite:dev",

--- a/src-tauri/tauri.qa.conf.json
+++ b/src-tauri/tauri.qa.conf.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schema.tauri.app/config/2.0.2",
     "productName": "Chorus Nightly",
-    "version": "0.14.4",
+    "version": "0.14.5",
     "identifier": "sh.chorus.app.qa",
     "build": {
         "beforeDevCommand": "pnpm vite:dev",

--- a/src/core/chorus/OpenAICompletionsAPIUtils.ts
+++ b/src/core/chorus/OpenAICompletionsAPIUtils.ts
@@ -199,7 +199,7 @@ function convertToolCalls(
     // adapted from a snippet on https://platform.openai.com/docs/guides/function-calling?api-mode=chat&lang=javascript
     // which appears to be severely buggy (lol)
     for (const chunk of chunks) {
-        const toolCallDeltas = chunk.choices[0].delta.tool_calls || [];
+        const toolCallDeltas = chunk.choices?.[0]?.delta?.tool_calls || [];
         for (const toolCallDelta of toolCallDeltas) {
             const index = toolCallDelta.index ?? 0;
 


### PR DESCRIPTION
All streams were ending on:
UNDEFINED IS NOT AN OBJECT (EVALUATING 'I.CHOICES[0].DELTA')

so when you had tool calls, this actually failed quite early (as soon as the stream before the tool call, ended)
the fix was one single line in OpenAICompletionsAPIUtils.ts, line 202:
 - const toolCallDeltas = chunk.choices[0].delta.tool_calls || [];
 + const toolCallDeltas = chunk.choices?.[0]?.delta?.tool_calls || [];
 
 