### PR TITLE
Fix crash when OpenRouter sends chunks with empty choices array

### DIFF
--- a/src/core/chorus/OpenAICompletionsAPIUtils.ts
+++ b/src/core/chorus/OpenAICompletionsAPIUtils.ts
@@ -199,7 +199,7 @@ function convertToolCalls(
     // adapted from a snippet on https://platform.openai.com/docs/guides/function-calling?api-mode=chat&lang=javascript
     // which appears to be severely buggy (lol)
     for (const chunk of chunks) {
-        const toolCallDeltas = chunk.choices[0].delta.tool_calls || [];
+        const toolCallDeltas = chunk.choices?.[0]?.delta?.tool_calls || [];
         for (const toolCallDelta of toolCallDeltas) {
             const index = toolCallDelta.index ?? 0;
 


### PR DESCRIPTION
## Summary

- OpenRouter (and OpenAI-compatible providers) can send SSE chunks where `choices` is an empty array (e.g. final usage/close chunks, as documented in OpenRouter streaming + OpenAI `stream_options.include_usage`).
- `OpenAICompletionsAPIUtils.ts` was unconditionally accessing `chunk.choices[0].delta.tool_calls`, crashing with `undefined is not an object` on every OpenRouter streaming call that includes those chunks.
- Fix: use optional chaining `chunk.choices?.[0]?.delta?.tool_calls || []` so empty-choices chunks are silently skipped.

## Test plan

- [ ] Start a chat with an OpenRouter model that uses streaming — verify it completes without crashing
- [ ] Start a chat that involves tool calls via OpenRouter — verify tool calls complete correctly
- [ ] Verify non-OpenRouter providers (Anthropic, OpenAI direct) still work normally

by-claude